### PR TITLE
#8 add build and release github action

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -32,18 +32,17 @@ jobs:
         run: |
           pyinstaller --clean FarbenWolf.spec
           if (!(Test-Path release)) { New-Item -ItemType Directory -Path release }
-          Push-Location dist\FarbenWolf
-          Compress-Archive -Path FarbenWolf.exe, _internals -DestinationPath ../../release/FarbenWolf.zip
-          Pop-Location
+          Compress-Archive -Path dist\* -DestinationPath release\FarbenWolf.zip
 
       - name: Upload artifact (only on main branch)
-        #if: |
-        #  startsWith(github.ref, 'refs/heads/main') ||
-        #  startsWith(github.ref, 'refs/pull/')
+        if: |
+          startsWith(github.ref, 'refs/heads/main') ||
+          startsWith(github.ref, 'refs/pull/')
         uses: actions/upload-artifact@v4
         with:
-          name: FarbenWolf
+          name: farbenwolf-build
           path: release\FarbenWolf.zip
+
 
   release:
     runs-on: ubuntu-latest
@@ -54,7 +53,7 @@ jobs:
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:
-          name: FarbenWolf
+          name: farbenwolf-build
           path: release/
 
       - name: Create GitHub Release


### PR DESCRIPTION
## GitHub Actions: Build & Release

Dieser Workflow automatisiert den Build und Release von **FarbenWolf**.

### Trigger
- Push auf beliebige Branches
- Push von Tags `v*.*.*` (z.B. `v1.2.3`)

### Jobs

**1. Build (Windows)**
- Checkt den Code aus
- Installiert Python 3.12 und Requirements
- Baut `FarbenWolf.exe` via PyInstaller
- Packt `FarbenWolf.exe` + `_internals` in `release/FarbenWolf.zip`
- Lädt ZIP als Artifact `farbenwolf-build` hoch (nur main / PR)

**2. Release (Ubuntu)**
- Lädt Build Artifact herunter
- Erstellt GitHub Release bei Tag-Push
- Fügt `FarbenWolf.zip` als Release Asset hinzu

Ergebnis: `FarbenWolf.zip` enthält die fertige `.exe` und den `_internals` Ordner.

Closes #8 